### PR TITLE
Stop form from passing lists

### DIFF
--- a/mysite/flask_app.py
+++ b/mysite/flask_app.py
@@ -22,7 +22,7 @@ def pc_jenny():
         form = {
             **{f'{f}_{N}': None for f in FORM_FIELDS},
             **{f'description_{N}': ''},
-            **raw_form
+            **raw_form.to_dict()
         }
         return {
             'specie': jenny_schema.Specie(


### PR DESCRIPTION
I suspect that certain versions of the immutable dict type (output of `request.form`) don't cleanly convert values for keys; had a problem where the values were passed as lists. This is the fix!